### PR TITLE
Upgraded the plugin to utilize authorization plugin v2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply from: 'plugin-helpers.gradle'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-project.ext.pluginVersion = '2.0.0'
+project.ext.pluginVersion = '3.0.0'
 project.ext.fullVersion = project.git.distVersion() ? "${project.pluginVersion}-${project.git.distVersion()}" : project.pluginVersion
 
 version = project.fullVersion
@@ -34,7 +34,7 @@ project.ext.pluginDesc = [
         id         : 'cd.go.authorization.google',
         repo       : rootProject.name,
         version    : project.fullVersion,
-        goCdVersion: '17.5.0',
+        goCdVersion: '19.2.0',
         name       : 'Google oauth authorization plugin',
         description: 'Google oauth authorization plugin for GoCD',
         vendorName : 'GoCD Contributors',

--- a/src/main/java/cd/go/authorization/google/Constants.java
+++ b/src/main/java/cd/go/authorization/google/Constants.java
@@ -25,7 +25,7 @@ public interface Constants {
     String EXTENSION_TYPE = "authorization";
 
     // The extension point API version that this plugin understands
-    String API_VERSION = "1.0";
+    String API_VERSION = "2.0";
 
     // the identifier of this plugin
     GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(API_VERSION));

--- a/src/main/java/cd/go/authorization/google/GooglePlugin.java
+++ b/src/main/java/cd/go/authorization/google/GooglePlugin.java
@@ -42,7 +42,7 @@ public class GooglePlugin implements GoPlugin {
     }
 
     @Override
-    public GoPluginApiResponse handle(GoPluginApiRequest request) throws UnhandledRequestTypeException {
+    public GoPluginApiResponse handle(GoPluginApiRequest request) {
         try {
             switch (RequestFromServer.fromString(request.requestName())) {
                 case REQUEST_GET_PLUGIN_ICON:

--- a/src/main/java/cd/go/authorization/google/executors/GetCapabilitiesRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/google/executors/GetCapabilitiesRequestExecutor.java
@@ -31,6 +31,6 @@ public class GetCapabilitiesRequestExecutor {
     }
 
     Capabilities getCapabilities() {
-        return new Capabilities(SupportedAuthType.Web, true, false);
+        return new Capabilities(SupportedAuthType.Web, true, false, false);
     }
 }

--- a/src/main/java/cd/go/authorization/google/executors/RequestFromServer.java
+++ b/src/main/java/cd/go/authorization/google/executors/RequestFromServer.java
@@ -36,7 +36,8 @@ public enum RequestFromServer {
     REQUEST_SEARCH_USERS(Constants.REQUEST_PREFIX + ".search-users"),
 
     REQUEST_AUTHORIZATION_SERVER_REDIRECT_URL(Constants.REQUEST_PREFIX + ".authorization-server-url"),
-    REQUEST_ACCESS_TOKEN(Constants.REQUEST_PREFIX + ".fetch-access-token");
+    REQUEST_ACCESS_TOKEN(Constants.REQUEST_PREFIX + ".fetch-access-token"),
+    REQUEST_IS_VALID_USER(String.join(".", Constants.REQUEST_PREFIX, "is-valid-user"));
 
     private final String requestName;
 

--- a/src/main/java/cd/go/authorization/google/models/Capabilities.java
+++ b/src/main/java/cd/go/authorization/google/models/Capabilities.java
@@ -31,11 +31,15 @@ public class Capabilities {
     @Expose
     @SerializedName("can_authorize")
     private final boolean canAuthorize;
+    @Expose
+    @SerializedName("can_get_user_roles")
+    private final boolean canGetUserRoles;
 
-    public Capabilities(SupportedAuthType supportedAuthType, boolean canSearch, boolean canAuthorize) {
+    public Capabilities(SupportedAuthType supportedAuthType, boolean canSearch, boolean canAuthorize, boolean canGetUserRoles) {
         this.supportedAuthType = supportedAuthType;
         this.canSearch = canSearch;
         this.canAuthorize = canAuthorize;
+        this.canGetUserRoles = canGetUserRoles;
     }
 
     public String toJSON() {

--- a/src/test/java/cd/go/authorization/google/executors/GetCapabilitiesRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/google/executors/GetCapabilitiesRequestExecutorTest.java
@@ -29,7 +29,8 @@ public class GetCapabilitiesRequestExecutorTest {
         String expectedJSON = "{\n" +
                 "    \"supported_auth_type\":\"web\",\n" +
                 "    \"can_authorize\":false,\n" +
-                "    \"can_search\":true\n" +
+                "    \"can_search\":true,\n" +
+                "    \"can_get_user_roles\":false\n" +
                 "}";
 
         JSONAssert.assertEquals(expectedJSON, response.responseBody(), true);


### PR DESCRIPTION
#### Note

1. Bumped up the plugin version to 2.0.0 and GoCD version to 19.2.0.
2. Updated the Capabilities API Endpoint version to v2.
3. Set the `get-roles` capability to false
4. Won't support `is-valid-user` and `get-roles` as there is no supporting Google API

Related Issue in GoCD: https://github.com/gocd/gocd/issues/5825